### PR TITLE
remove dependency on jinja

### DIFF
--- a/powerrelay/main.py
+++ b/powerrelay/main.py
@@ -21,8 +21,6 @@ import trafaret_config as traf_cfg
 import trafaret as t
 
 from aiohttp import web
-import aiohttp_jinja2
-import jinja2
 
 import gpiod
 
@@ -159,9 +157,6 @@ def run(config):
 
         # setup application and extensions
         app = web.Application(middlewares=[terminate_exception_body_by_newline])
-
-        # setup jinja template
-        aiohttp_jinja2.setup(app, loader=jinja2.PackageLoader('powerrelay','views'))
 
         # setup gpio line instances
         lines = dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 click==6.7
 aiohttp==3.0.6
-aiohttp-jinja2==0.14.0
 trafaret==1.2.0
 trafaret-config==2.0.2
 yarl==1.1.1


### PR DESCRIPTION
It turns out that we don't actually use the jinja framework, at least
not since commit 74894ad which somewhat brutally removed the dummy
views/*.j2 files. For some reason it still used to work, but now
apparently some change in jinja makes us fail with

  ValueError: The 'powerrelay' package was not installed in a way that PackageLoader understands.

Getting one less dependency is nice.