### PR TITLE
main.py: add try/except to correctly find the line of interest

### DIFF
--- a/powerrelay/main.py
+++ b/powerrelay/main.py
@@ -101,7 +101,10 @@ def cfg_to_gpiochip_and_offset(cfg):
         for entry in os.scandir("/dev/"):
             if gpiod.is_gpiochip_device(entry.path):
                 with gpiod.Chip(entry.path) as chip:
-                    offset = chip.line_offset_from_id(name)
+                    try:
+                        offset = chip.line_offset_from_id(name)
+                    except:
+                        continue
                     if offset is not None:
                         return chip.get_info().name, offset
         raise Exception("No such GPIO")


### PR DESCRIPTION
Moving to gpiolib 2.0 changed the core functionality as described in '2bf68ddb1f8421fc9cbf6c1a7e7478b233ee5a9e'. This means that simply searching by name, for example, "RELAY0", is not guaranteed to work. To circumvent this change, we utilize a try/except block. Note, however, that we do not handle the exception; we simply continue instead. This is because the name might not exist in the current gpiochip, but in another.