### PR TITLE
controllers/relay: Use plain text response in get_state

### DIFF
--- a/powerrelay/controllers/relay.py
+++ b/powerrelay/controllers/relay.py
@@ -82,7 +82,7 @@ class RelayController:
         ident = request.match_info['relay']
         line = self.lookup_line(ident)
 
-        return self.json_response(str(line.request.get_values()[0].value))
+        return web.Response(text=str(line.request.get_values()[0].value))
 
 
     async def set_state_old(self,request):


### PR DESCRIPTION
This allows labgrid-clients to read the state. The drivers in labgrid do not expect a JSON response.
The power and io command from labgrid-client can return a proper response (on/off or high/low).